### PR TITLE
Format out-of-range Share API readings as Low/Hi

### DIFF
--- a/Sources/Dexcom/Constants.swift
+++ b/Sources/Dexcom/Constants.swift
@@ -28,6 +28,14 @@ extension Measurement<UnitDuration> {
 
 extension Int {
     public static let maxGlucoseCount = Int(Measurement.maxGlucoseDuration.converted(to: .minutes).value / 5)
+
+    /// Sentinel value reported by the Share API for a reading below the
+    /// sensor's measurable range (40–400 mg/dL). Displayed as "Low".
+    static let lowestGlucoseValue = 39
+
+    /// Sentinel value reported by the Share API for a reading above the
+    /// sensor's measurable range (40–400 mg/dL). Displayed as "Hi".
+    static let highestGlucoseValue = 401
 }
 
 extension Double {

--- a/Sources/Dexcom/GlucoseFormatter.swift
+++ b/Sources/Dexcom/GlucoseFormatter.swift
@@ -20,11 +20,24 @@ public struct GlucoseFormatter: FormatStyle, Sendable {
     }
 
     public func format(_ value: Int) -> String {
+        // The Share API reports sentinel values when a reading is outside the
+        // sensor's measurable range (40–400 mg/dL): 39 means below range and
+        // 401 means above range. These aren't real numbers, so display them as
+        // "Low"/"Hi" regardless of unit. The casing assumes the caller applies
+        // small caps (e.g. SwiftUI's `.lowercaseSmallCaps()`) at display time.
+        if value <= .lowestGlucoseValue {
+            return "Low"
+        }
+
+        if value >= .highestGlucoseValue {
+            return "Hi"
+        }
+
         switch unit {
         case .mgdl:
-            value.formatted(.number.precision(.fractionLength(0)))
+            return value.formatted(.number.precision(.fractionLength(0)))
         case .mmolL:
-            (Double(value) * .mmolConversionFactor).formatted(.number.precision(.fractionLength(1)))
+            return (Double(value) * .mmolConversionFactor).formatted(.number.precision(.fractionLength(1)))
         }
     }
 }

--- a/Tests/DexcomTests/GlucoseFormatterTests.swift
+++ b/Tests/DexcomTests/GlucoseFormatterTests.swift
@@ -11,4 +11,22 @@ final class GlucoseFormatterTests: XCTestCase {
         XCTAssertEqual(100.formatted(.glucose(.mmolL)), "5.6")
         XCTAssertEqual(101.formatted(.glucose(.mmolL)), "5.6")
     }
+
+    func test_low() throws {
+        XCTAssertEqual(39.formatted(.glucose(.mgdl)), "Low")
+        XCTAssertEqual(39.formatted(.glucose(.mmolL)), "Low")
+        // Anything at or below the low sentinel is still "Low".
+        XCTAssertEqual(38.formatted(.glucose(.mgdl)), "Low")
+        // 40 is the lowest real reading and should format normally.
+        XCTAssertEqual(40.formatted(.glucose(.mgdl)), "40")
+    }
+
+    func test_high() throws {
+        XCTAssertEqual(401.formatted(.glucose(.mgdl)), "Hi")
+        XCTAssertEqual(401.formatted(.glucose(.mmolL)), "Hi")
+        // Anything at or above the high sentinel is still "Hi".
+        XCTAssertEqual(402.formatted(.glucose(.mgdl)), "Hi")
+        // 400 is the highest real reading and should format normally.
+        XCTAssertEqual(400.formatted(.glucose(.mgdl)), "400")
+    }
 }


### PR DESCRIPTION
The Share API reports sentinel values for readings outside the sensor's
measurable range (40–400 mg/dL): 39 for below range and 401 for above.
GlucoseFormatter now renders these as "Low"/"Hi" in both mg/dL and mmol/L
rather than as literal numbers. Casing is chosen so callers can apply
small caps (e.g. SwiftUI's .lowercaseSmallCaps()) at display time.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017GcUyZpDx4nwNJqrAPuwwU